### PR TITLE
Added options for reddit and an additional simple view

### DIFF
--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -52,3 +52,19 @@ msgstr ""
 msgctxt "#32406"
 msgid "Lens Blog - The New York Times"
 msgstr ""
+
+msgctxt "#32407"
+msgid "View"
+msgstr ""
+
+msgctxt "#32408"
+msgid "Normal"
+msgstr ""
+
+msgctxt "#32409"
+msgid "Simple"
+msgstr ""
+
+msgctxt "#32410"
+msgid "Reddit"
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -6,5 +6,6 @@
     <setting id="enable_SacBeeFrame" type="bool" label="32402" default="true"/>
     <setting id="enable_WallStreetJournal" type="bool" label="32403" default="true"/>
     <setting id="enable_TotallyCoolPix" type="bool" label="32404" default="true"/>
+	<setting id="enable_Reddit" type="bool" label="32410" default="true"/>
      <setting id="choose_view" type="enum" label="32407" lvalues="32408|32409"/>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-    <setting id="choose_view" type="enum" label="32407" lvalues="32408|32409"/>
+    <setting id="choose_view" type="enum" label="32407" lvalues="32408|32409" default="0"/>
     <setting id="picture_duration" type="number" label="32110" default="5"/>
     <setting id="enable_TheBigPictures" type="bool" label="32400" default="true"/>
     <setting id="enable_AtlanticInFocus" type="bool" label="32401" default="true"/>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
+    <setting id="choose_view" type="enum" label="32407" lvalues="32408|32409"/>
     <setting id="picture_duration" type="number" label="32110" default="5"/>
     <setting id="enable_TheBigPictures" type="bool" label="32400" default="true"/>
     <setting id="enable_AtlanticInFocus" type="bool" label="32401" default="true"/>
     <setting id="enable_SacBeeFrame" type="bool" label="32402" default="true"/>
     <setting id="enable_WallStreetJournal" type="bool" label="32403" default="true"/>
     <setting id="enable_TotallyCoolPix" type="bool" label="32404" default="true"/>
-	<setting id="enable_Reddit" type="bool" label="32410" default="true"/>
-     <setting id="choose_view" type="enum" label="32407" lvalues="32408|32409"/>
+    <setting id="enable_Reddit" type="bool" label="32410" default="true"/>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -6,4 +6,5 @@
     <setting id="enable_SacBeeFrame" type="bool" label="32402" default="true"/>
     <setting id="enable_WallStreetJournal" type="bool" label="32403" default="true"/>
     <setting id="enable_TotallyCoolPix" type="bool" label="32404" default="true"/>
+     <setting id="choose_view" type="enum" label="32407" lvalues="32408|32409"/>
 </settings>

--- a/resources/skins/default/720p/script-The Big Pictures Screensaver-simple.xml
+++ b/resources/skins/default/720p/script-The Big Pictures Screensaver-simple.xml
@@ -14,7 +14,7 @@
             <posx>0</posx>
             <posy>0</posy>
             <width></width><!-- this will be set from the python code -->
-            <height>auto</height>
+            <height></height>
             <fadetime>1000</fadetime>
             <aspectratio>scale</aspectratio>
         </control>

--- a/resources/skins/default/720p/script-The Big Pictures Screensaver-simple.xml
+++ b/resources/skins/default/720p/script-The Big Pictures Screensaver-simple.xml
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window type="window">
+    <controls>
+        <control type="image" id="30002">
+            <description>The spinning animation in the background</description>
+            <posx>607</posx>
+            <posy>327</posy>
+            <width>66</width>
+            <height>66</height>
+            <texture>loader.gif</texture>
+        </control>
+        <control type="largeimage" id="30001">
+            <description>The big picture</description>
+            <posx>0</posx>
+            <posy>0</posy>
+            <width></width><!-- this will be set from the python code -->
+            <height>auto</height>
+            <fadetime>1000</fadetime>
+            <aspectratio>scale</aspectratio>
+        </control>
+        <control type="label" id="30003">
+            <description>Label for source title</description>
+            <right>20</right>
+            <bottom>15</bottom>
+            <width>400</width>
+            <height>20</height>
+            <align>right</align>
+            <aligny>center</aligny>
+            <textcolor>FFFFFFFF</textcolor>
+            <font>font13</font>
+        </control>
+        <control type="label" id="30004">
+            <description>Label for picture title</description>
+            <left>20</left>
+            <bottom>15</bottom>
+            <width>820</width>
+            <height>20</height>
+            <align>left</align>
+            <aligny>center</aligny>
+            <textcolor>FFFFFFFF</textcolor>
+            <font>font13</font>
+            <scroll>true</scroll>
+        </control>
+        <control type="largeimage" id="30006">
+            <description>The xext big picture (for preloading)</description>
+            <posx>1280</posx>
+            <posy>0</posy>
+            <width>16</width>
+            <height>9</height>
+            <aspectratio>keep</aspectratio>
+        </control>
+    </controls>
+</window>

--- a/screensaver.py
+++ b/screensaver.py
@@ -59,6 +59,7 @@ class Screensaver(xbmcgui.WindowXMLDialog):
             self.description_control = self.getControl(30005)
         elif int(addon.getSetting('choose_view')) == 1:
             self.picture_control.setWidth(self.getWidth())
+            self.picture_control.setHeight(self.getHeight())
         self.get_scrapers()
         self.slideshow()
 

--- a/screensaver.py
+++ b/screensaver.py
@@ -49,13 +49,16 @@ class Screensaver(xbmcgui.WindowXMLDialog):
         self.loader_control = self.getControl(30002)
         self.source_control = self.getControl(30003)
         self.title_control = self.getControl(30004)
-        self.description_control = self.getControl(30005)
         self.next_picture_control = self.getControl(30006)
 
         self.picture_duration = (
             int(addon.getSetting('picture_duration')) * 1000
         )
 
+        if int(addon.getSetting('choose_view')) == 0:
+            self.description_control = self.getControl(30005)
+        elif int(addon.getSetting('choose_view')) == 1:
+            self.picture_control.setWidth(self.getWidth())
         self.get_scrapers()
         self.slideshow()
 
@@ -100,7 +103,9 @@ class Screensaver(xbmcgui.WindowXMLDialog):
         self.picture_control.setImage(picture_url)
         self.source_control.setLabel(photo['source'])
         self.title_control.setLabel(photo['title'])
-        self.description_control.setText(photo['description'])
+        if int(addon.getSetting('choose_view')) == 0:
+            self.description_control.setText(photo['description'])
+
 
     def preload_next_photo(self, photo):
         picture_url = photo['pic']
@@ -117,11 +122,19 @@ class Screensaver(xbmcgui.WindowXMLDialog):
 
 
 if __name__ == '__main__':
-    screensaver = Screensaver(
-        'script-%s-main.xml' % addon_name,
-        addon_path,
-        'default',
-    )
+    if int(addon.getSetting('choose_view')) == 0:
+        screensaver = Screensaver(
+            'script-%s-main.xml' % addon_name,
+            addon_path,
+            'default',
+        )
+    elif int(addon.getSetting('choose_view')) == 1:
+        screensaver = Screensaver(
+            'script-%s-simple.xml' % addon_name,
+            addon_path,
+            'default',
+        )
+
     screensaver.doModal()
     del screensaver
     sys.modules.clear()


### PR DESCRIPTION
Hey there,

I added some code to enable the reddit scrapper from the modules part of the addon (PR in the other repo)

And I've added another view that is pretty much only the picture, with very basic info on the bottom. Your skin is still the default, but you can find a new setting where you can switch between "Normal" (the old) and "Simple".

Cheers
